### PR TITLE
Bug fix: leidžiami nepilni slaptažodžiai registracijos metu

### DIFF
--- a/boilerplate/src/Locale/lt/default.po
+++ b/boilerplate/src/Locale/lt/default.po
@@ -420,6 +420,12 @@ msgstr "Bonusinė užduotis (Investment Criteria)"
 msgid "home.tasks.task4.description"
 msgstr "Sukurkite galimybę investuotojui nurodyti kriterijus pagal kuriuos galėtų investuoti. Siūlomi kriterijai: kredito įvertinimas ir nemokumo tikimybė, paskolos suma ir terminas, palūkanų normos lūkesčiai, rizikos tolerancijos lygis, skolininko pajamų patvirtinimas, paskolos paskirtis ir užstatas, geografinės preferencijos, diversifikacija tarp kelių paskolų. Pagalvokite ir pasiūlykite papildomus kriterijus."
 
+msgid "Password must be at least 6 characters long"
+msgstr "Slaptažodis turi būti ne mažesnis nei 6 simboliai"
+
+msgid "Minimum 6 characters"
+msgstr "Mažiausiai 6 simboliai"
+
 msgid "home.login_button"
 msgstr "Prisijungti"
 

--- a/boilerplate/src/Model/Table/UsersTable.php
+++ b/boilerplate/src/Model/Table/UsersTable.php
@@ -59,13 +59,14 @@ class UsersTable extends Table
 
         $validator
             ->email('email')
-            ->allowEmptyString('email')
+            ->notEmptyString('email')
             ->add('email', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
 
         $validator
             ->scalar('password')
             ->maxLength('password', 255)
-            ->allowEmptyString('password');
+            ->notEmptyString('password')
+            ->minLength('password', 6);
 
         $validator
             ->scalar('role')

--- a/boilerplate/src/Model/Table/UsersTable.php
+++ b/boilerplate/src/Model/Table/UsersTable.php
@@ -66,7 +66,7 @@ class UsersTable extends Table
             ->scalar('password')
             ->maxLength('password', 255)
             ->notEmptyString('password')
-            ->minLength('password', 6);
+            ->minLength('password', 6, __('Password must be at least 6 characters long'));
 
         $validator
             ->scalar('role')

--- a/boilerplate/src/View/Helper/UserFormHelper.php
+++ b/boilerplate/src/View/Helper/UserFormHelper.php
@@ -18,7 +18,9 @@ class UserFormHelper extends Helper
         $html = '';
 
         $html .= $this->Form->control('email');
-        $html .= $this->Form->control('password');
+        $html .= $this->Form->control('password', [
+            'help' => __('Minimum 6 characters')
+        ]);
 
         if (!empty($options['showRole'])) {
             $html .= $this->Form->control('role', [


### PR DESCRIPTION
Problema: User formose nėra atlikti 'validation' žingsniai.

Sprendimas:

Pridėti 'validations' UsersTable klasėje. Pridėtos pagalbinės žinutės naudotojams.

Pastaba: trūksta standartinės Csfr apsaugos. Pridėtas min simbolių reikalavimas (reikėtų konsultuotis ar reikalinga, kadangi nebuvo reikalavimo aprašyme) .

Rankinis testavimas:

1. Patikrinti visas Users formas (add, edit, register) ar yra atliekami 'validations'.
   a) Tuščias slaptažodis.
   b) Mažiau nei min simbolių.

PS: Netinkamas sprendimas PR request daryti egzistuojančiam branch, kuris taip pat turi PR. Tačiau tam, kad būtų lengviau suprasti būtent šio bug pakeitimus, užduoties metu buvo pasirinktas toks sprendimas.