### PR TITLE
Bug fix: update route for callback

### DIFF
--- a/boilerplate/config/routes.php
+++ b/boilerplate/config/routes.php
@@ -91,7 +91,7 @@ Router::scope('/', function (RouteBuilder $routes) {
     $routes->connect('/payments/build-request/:id', ['controller' => 'Payments', 'action' => 'buildRequest'])
         ->setPass(['id']);
 
-    $routes->connect('/payments/callback', ['controller' => 'Payments', 'action' => 'callback']);
+    $routes->connect('/client-payments/callback', ['controller' => 'ClientPayments', 'action' => 'callback']);
 
     $routes->fallbacks(DashedRoute::class);
 });

--- a/boilerplate/src/Template/ClientPayments/topup.ctp
+++ b/boilerplate/src/Template/ClientPayments/topup.ctp
@@ -341,7 +341,7 @@
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label" for="amount"><?= __('topup.form.custom_amount_label') ?></label>
+                    <label class="form-label" for="amount-input"><?= __('topup.form.custom_amount_label') ?></label>
                     <?= $this->Form->control('amount', [
                         'type' => 'number',
                         'class' => 'form-input',


### PR DESCRIPTION
Problema: Naudotojui atlikus 'topup' funkcija nėra atnaujinamos lėšos.

Naudojant logs pastebėta, jog callback funkcija nėra įvykdoma.
Pastebėta, kad naudojamas netinkamas ID topup.ctp formoj.

Sprendimas:

Atnaujinti routes. Pataisytas ID.

Rankinis testavimas:

Atlikti pilną 'topup' workflow naudojant įvairias sumas. Patikrinti ar suma yra atnaujinta duombazėje, UI. Ar yra sukurti 'transactions' ir 'wallet' atnaujinimai.

PS: Ištestuoti pilnai neišėjo. Manau, jog Paysera callback atlieka server to server metodu, o mano aplikacija paleista lokaliai. Todėl nėra gaunamas atsakas. Bet būtų įdomu suprasti kaip šį 'issue' reikėjo sutaisyti.